### PR TITLE
Enable web support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -19,6 +19,7 @@ assignees: ''
 - [ ] Windows executable (`windows.zip`)
 - [ ] Pyxel executable (`pyxel-dist.zip`)
 - [ ] Pure Python (`source.zip`)
+- [ ] Web version (in-browser)
 
 **Environment**
 <!--- Provide details of your environment to reproduce this issue. --->

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ If you have [Nox](https://nox.thea.codes) and the Python required version (see a
 of commands to generate the source zip, the Pyxel executable and the Windows executable (if running under Windows). The final
 contents will be found on a `dist` folder [^1].
 
+### Web support!
+
+Try out the latest dist: **the Pyxel web version!** See it [here](https://kitao.github.io/pyxel/wasm/launcher/?run=DiddiLeija.diddi-and-the-bugs...main).
+
 ## How to win
 
 Use the energized serum to destroy **200 bugs** and win! In the meantime, you can earn extra points

--- a/main.py
+++ b/main.py
@@ -254,6 +254,7 @@ class App:
         self.on_menu = True  # variable to show the menu
 
         self.startup()
+        pyxel.run(self.update, self.draw)
 
     def reset_game(self):
         self.alive = True  # the player is still alive
@@ -300,11 +301,21 @@ at github.com/DiddiLeija/diddi-and-the-bugs
     def startup(self):
         if self.on_menu:
             self.reset_menu()
-            pyxel.run(self.update_menu, self.draw_menu)
         else:
             self.reset_game()
             self.add_message("Let's go!")
-            pyxel.run(self.update_game, self.draw_game)
+
+    def update(self):
+        if self.on_menu:
+            self.update_menu()
+        else:
+            self.update_game()
+
+    def draw(self):
+        if self.on_menu:
+            self.draw_menu()
+        else:
+            self.draw_game()
 
     def update_game(self):
         if pyxel.btnp(pyxel.KEY_Q):


### PR DESCRIPTION
Closes #84. As I said before, this fix avoids `pyxel.run` to be called multiple times.

cc @HarshNarayanJha